### PR TITLE
fix: wrong workflow url

### DIFF
--- a/.github/workflows/backup-to-gitlab.yml
+++ b/.github/workflows/backup-to-gitlab.yml
@@ -7,6 +7,6 @@ concurrency:
 
 jobs:
   backup-to-gitlabwh:
-    uses: deepin-community/.github/.github/workflows/backup-to-gitlabwh.yml@master
+    uses: linuxdeepin/.github/.github/workflows/backup-to-gitlabwh.yml@master
     secrets:
       BRIDGETOKEN: ${{ secrets.BRIDGETOKEN }}


### PR DESCRIPTION
linuxdeepin组织下的仓库应该使用linuxdeepin/.github仓库的工作流

Log: